### PR TITLE
#101 showing document size, create date and type

### DIFF
--- a/src/main/java/com/nerodesk/om/Doc.java
+++ b/src/main/java/com/nerodesk/om/Doc.java
@@ -33,6 +33,7 @@ import com.jcabi.aspects.Immutable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Date;
 
 /**
  * Document.
@@ -56,6 +57,27 @@ public interface Doc {
      * @throws IOException If fails
      */
     void delete() throws IOException;
+
+    /**
+     * Size of the document in bytes.
+     * @return Number of bytes
+     * @throws IOException If fails
+     */
+    long size() throws IOException;
+
+    /**
+     * Mime type of the document.
+     * @return Mime type.
+     * @throws IOException If fails
+     */
+    String type() throws IOException;
+
+    /**
+     * Timestamp when the document was created.
+     * @return Date in UTC.
+     * @throws IOException If fails
+     */
+    Date created() throws IOException;
 
     /**
      * Everybody who has access to this document.

--- a/src/main/java/com/nerodesk/om/aws/AwsDoc.java
+++ b/src/main/java/com/nerodesk/om/aws/AwsDoc.java
@@ -30,6 +30,7 @@
 package com.nerodesk.om.aws;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.jcabi.aspects.Tv;
 import com.jcabi.log.Logger;
 import com.jcabi.s3.Bucket;
 import com.jcabi.s3.Ocket;
@@ -38,6 +39,7 @@ import com.nerodesk.om.Friends;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Date;
 import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 
@@ -47,6 +49,10 @@ import lombok.EqualsAndHashCode;
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 0.2
+ * @todo #101:30min Methods size, type and created have to replaced with correct
+ *  implementation. Size should give number of bytes of the document, type
+ *  should be MIME type of the document, created should be a timestamp when the
+ *  document was created.
  */
 @EqualsAndHashCode(of = { "bucket", "user", "label" })
 final class AwsDoc implements Doc {
@@ -91,6 +97,21 @@ final class AwsDoc implements Doc {
     @Override
     public void delete() throws IOException {
         this.bucket.remove(this.ocket().key());
+    }
+
+    @Override
+    public long size() throws IOException {
+        return Tv.MILLION;
+    }
+
+    @Override
+    public String type() throws IOException {
+        return "application/octet-stream";
+    }
+
+    @Override
+    public Date created() throws IOException {
+        return new Date();
     }
 
     @Override

--- a/src/main/java/com/nerodesk/om/mock/MkDoc.java
+++ b/src/main/java/com/nerodesk/om/mock/MkDoc.java
@@ -38,6 +38,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Date;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
@@ -85,6 +88,25 @@ public final class MkDoc implements Doc {
     @Override
     public void delete() {
         this.file().delete();
+    }
+
+    @Override
+    public long size() throws IOException {
+        return FileUtils.sizeOf(this.file());
+    }
+
+    @Override
+    public String type() throws IOException {
+        return Files.probeContentType(this.file().toPath());
+    }
+
+    @Override
+    public Date created() throws IOException {
+        return new Date(
+            Files.readAttributes(
+                this.file().toPath(), BasicFileAttributes.class
+            ).creationTime().toMillis()
+        );
     }
 
     @Override

--- a/src/main/java/com/nerodesk/takes/TkDocs.java
+++ b/src/main/java/com/nerodesk/takes/TkDocs.java
@@ -100,6 +100,10 @@ public final class TkDocs implements Take {
             final Href href = home.path("doc").with("file", name);
             dirs.add("doc")
                 .add("name").set(name).up()
+                .add("size").set(Long.toString(doc.size())).up()
+                .add("created").set(Long.toString(doc.created().getTime())).up()
+                .add("type").set(doc.type()).up()
+                .add("name").set(name).up()
                 .add("read").set(href.path("read").toString()).up()
                 .add("delete").set(href.path("delete").toString()).up()
                 .add("add-friend").set(href.path("add-friend").toString()).up()

--- a/src/main/xsl/docs.xsl
+++ b/src/main/xsl/docs.xsl
@@ -56,6 +56,18 @@
     <xsl:template match="doc">
         <li>
             <xsl:value-of select="name"/>
+            <xsl:text>, </xsl:text>
+            <xsl:value-of select="size"/>
+            <xsl:text> bytes, </xsl:text>
+            <!--
+            @todo #101:30min Creation date of document should be displayed using
+             ISO_8601 combined date time and timezone
+             (e.g. 2007-04-05T12:30-02:00). Right now it is just a unix
+             timestamp.
+            -->
+            <xsl:value-of select="created"/>
+            <xsl:text>, </xsl:text>
+            <xsl:value-of select="type"/>
             <xsl:text> </xsl:text>
             <a href="{read}">read</a>
             <xsl:text> | </xsl:text>

--- a/src/test/java/com/nerodesk/om/mock/MkDocTest.java
+++ b/src/test/java/com/nerodesk/om/mock/MkDocTest.java
@@ -30,11 +30,14 @@
 package com.nerodesk.om.mock;
 
 import com.google.common.io.Files;
+import com.nerodesk.om.Doc;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
@@ -135,6 +138,69 @@ public final class MkDocTest {
         MatcherAssert.assertThat(
             Files.toString(file, StandardCharsets.UTF_8),
             Matchers.equalTo(content)
+        );
+    }
+
+    /**
+     * MkDoc can guess content type.
+     * @throws IOException In case of error
+     */
+    @Test
+    public void guessesContentType() throws IOException {
+        final File file = new File(this.folder.newFolder(), "findout");
+        final String content = "Ordinary text content.";
+        final Doc doc = new MkDoc(file, "", "");
+        doc.write(
+            new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
+        );
+        MatcherAssert.assertThat(
+            doc.type(),
+            Matchers.equalTo("text/plain")
+        );
+    }
+
+    /**
+     * MkDoc can count bytes in document.
+     * @throws IOException In case of error
+     */
+    @Test
+    public void countsBytesInDocument() throws IOException {
+        final File file = new File(this.folder.newFolder(), "size");
+        final String content = "count me";
+        final Doc doc = new MkDoc(file, "", "");
+        doc.write(
+            new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
+        );
+        MatcherAssert.assertThat(
+            doc.size(),
+            Matchers.equalTo((long) content.length())
+        );
+    }
+
+    /**
+     * MkDoc can retrieve file creation time.
+     * @throws IOException In case of error
+     */
+    @Test
+    public void retrievesFileCreationTime() throws IOException {
+        final File file = new File(this.folder.newFolder(), "time");
+        final String content = "some content";
+        final Date before = new Date();
+        final Doc doc = new MkDoc(file, "", "");
+        doc.write(
+            new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
+        );
+        final Date after = new Date();
+        MatcherAssert.assertThat(
+            TimeUnit.MILLISECONDS.toSeconds(doc.created().getTime()),
+            Matchers.allOf(
+                Matchers.greaterThanOrEqualTo(
+                    TimeUnit.MILLISECONDS.toSeconds(before.getTime())
+                ),
+                Matchers.lessThanOrEqualTo(
+                    TimeUnit.MILLISECONDS.toSeconds(after.getTime())
+                )
+            )
         );
     }
 }

--- a/src/test/java/com/nerodesk/om/mock/MkDocTest.java
+++ b/src/test/java/com/nerodesk/om/mock/MkDocTest.java
@@ -36,7 +36,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -185,20 +184,20 @@ public final class MkDocTest {
     public void retrievesFileCreationTime() throws IOException {
         final File file = new File(this.folder.newFolder(), "time");
         final String content = "some content";
-        final Date before = new Date();
+        final long before = System.currentTimeMillis();
         final Doc doc = new MkDoc(file, "", "");
         doc.write(
             new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
         );
-        final Date after = new Date();
+        final long after = System.currentTimeMillis();
         MatcherAssert.assertThat(
             TimeUnit.MILLISECONDS.toSeconds(doc.created().getTime()),
             Matchers.allOf(
                 Matchers.greaterThanOrEqualTo(
-                    TimeUnit.MILLISECONDS.toSeconds(before.getTime())
+                    TimeUnit.MILLISECONDS.toSeconds(before)
                 ),
                 Matchers.lessThanOrEqualTo(
-                    TimeUnit.MILLISECONDS.toSeconds(after.getTime())
+                    TimeUnit.MILLISECONDS.toSeconds(after)
                 )
             )
         );


### PR DESCRIPTION
#101

Added displaying of size, create date (as unix timestamp in milliseconds) and MIME type with each document/file.
AwsDoc uses mock values for now, and MkDoc retrieves the data from the filesystem.
