### PR TITLE
#137 recreated problem with encoding and fixed with takes upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <dependency>
             <groupId>org.takes</groupId>
             <artifactId>takes</artifactId>
-            <version>0.9.11</version>
+            <version>0.11.2</version>
         </dependency>
         <dependency>
             <groupId>com.restfb</groupId>

--- a/src/test/java/com/nerodesk/takes/TsAppTest.java
+++ b/src/test/java/com/nerodesk/takes/TsAppTest.java
@@ -115,12 +115,8 @@ public final class TsAppTest {
     /**
      * TsApp can launch web server in non-latin locale.
      * @throws Exception If fails
-     * @todo #137:30min Upgrade project to takes version >= 0.11.2 and enable
-     *  this test afterwards. Right now it fails with HTTP status != 200.
-     *  Upgrade to higher takes causes
      */
     @Test
-    @Ignore
     public void launchesWebServerInNonLatinLocale() throws Exception {
         final Locale def = Locale.getDefault();
         try {

--- a/src/test/java/com/nerodesk/takes/TsAppTest.java
+++ b/src/test/java/com/nerodesk/takes/TsAppTest.java
@@ -113,7 +113,7 @@ public final class TsAppTest {
     }
 
     /**
-     * Launches web server in non-latin locale.
+     * TsApp can launch web server in non-latin locale.
      * @throws Exception If fails
      * @todo #137:30min Upgrade project to takes version >= 0.11.2 and enable
      *  this test afterwards. Right now it fails with HTTP status != 200.
@@ -121,7 +121,7 @@ public final class TsAppTest {
      */
     @Test
     @Ignore
-    public void launchesInNonLatinLocale() throws Exception {
+    public void launchesWebServerInNonLatinLocale() throws Exception {
         final Locale def = Locale.getDefault();
         try {
             Locale.setDefault(Locale.CHINESE);

--- a/src/test/java/com/nerodesk/takes/TsAppTest.java
+++ b/src/test/java/com/nerodesk/takes/TsAppTest.java
@@ -43,6 +43,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.util.Locale;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpHeaders;
 import org.hamcrest.MatcherAssert;
@@ -109,6 +110,38 @@ public final class TsAppTest {
                 }
             }
         );
+    }
+
+    /**
+     * Launches web server in non-latin locale.
+     * @throws Exception If fails
+     * @todo #137:30min Upgrade project to takes version >= 0.11.2 and enable
+     *  this test afterwards. Right now it fails with HTTP status != 200.
+     *  Upgrade to higher takes causes
+     */
+    @Test
+    @Ignore
+    public void launchesInNonLatinLocale() throws Exception {
+        final Locale def = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.CHINESE);
+            final TsApp app = new TsApp(new MkBase());
+            new FtRemote(app).exec(
+                new FtRemote.Script() {
+                    @Override
+                    public void exec(final URI home) throws IOException {
+                        new JdkRequest(home)
+                            .fetch()
+                            .as(RestResponse.class)
+                            .assertStatus(HttpURLConnection.HTTP_OK)
+                            .as(XmlResponse.class)
+                            .assertXPath("/xhtml:html");
+                    }
+                }
+            );
+        } finally {
+            Locale.setDefault(def);
+        }
     }
 
     /**

--- a/src/test/java/com/nerodesk/takes/doc/TkAddFriendTest.java
+++ b/src/test/java/com/nerodesk/takes/doc/TkAddFriendTest.java
@@ -62,7 +62,7 @@ public final class TkAddFriendTest {
         final String friend = "Bob";
         MatcherAssert.assertThat(
             new RsPrint(new TkAddFriend(doc, friend).act()).print(),
-            Matchers.containsString("document shared")
+            Matchers.containsString("document+shared")
         );
     }
 


### PR DESCRIPTION
#137

I've recreated a test that recreates a problem with non-latin characters in the HTTP header and fixed it with upgrade of takes to version 0.11.2.
