### PR TITLE
try-with-resources for MkDoc.write

### DIFF
--- a/src/main/java/com/nerodesk/om/mock/MkDoc.java
+++ b/src/main/java/com/nerodesk/om/mock/MkDoc.java
@@ -46,7 +46,6 @@ import org.apache.commons.io.IOUtils;
 
 /**
  * Mocked version of doc.
- *
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 0.2
@@ -86,8 +85,11 @@ public final class MkDoc implements Doc {
     }
 
     @Override
-    public void delete() {
-        this.file().delete();
+    public void delete() throws IOException {
+        final File file = this.file();
+        if (!file.delete()) {
+            throw new IOException(String.format("Failed to delete %s", file));
+        }
     }
 
     @Override
@@ -125,7 +127,9 @@ public final class MkDoc implements Doc {
     public void write(final InputStream input) throws IOException {
         final File file = this.file();
         FileUtils.touch(file);
-        IOUtils.copy(input, new FileOutputStream(file));
+        try (final FileOutputStream output = new FileOutputStream(file)) {
+            IOUtils.copy(input, output);
+        }
         Logger.info(this, "%s saved", file);
     }
 

--- a/src/test/java/com/nerodesk/om/mock/MkDocTest.java
+++ b/src/test/java/com/nerodesk/om/mock/MkDocTest.java
@@ -120,7 +120,7 @@ public final class MkDocTest {
             file = new File(this.folder.newFolder(), "exception");
             FileUtils.touch(file);
             IOUtils.copy(
-                IOUtils.toInputStream("hello, world!"),
+                IOUtils.toInputStream("try to delete me"),
                 new FileOutputStream(file)
             );
         } catch (IOException e) {

--- a/src/test/java/com/nerodesk/om/mock/MkDocTest.java
+++ b/src/test/java/com/nerodesk/om/mock/MkDocTest.java
@@ -34,9 +34,12 @@ import com.nerodesk.om.Doc;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
@@ -104,6 +107,21 @@ public final class MkDocTest {
             file.exists(),
             Matchers.is(false)
         );
+    }
+
+    /**
+     * MkDoc can throw IOException on delete.
+     * @throws IOException In case of error
+     */
+    @Test (expected = IOException.class)
+    public void throwsIOExceptionOnDelete() throws IOException {
+        final File file = new File(this.folder.newFolder(), "exception");
+        FileUtils.touch(file);
+        IOUtils.copy(
+            IOUtils.toInputStream("hello, world!"),
+            new FileOutputStream(file)
+        );
+        new MkDoc(file, "", "").delete();
     }
 
     /**

--- a/src/test/java/com/nerodesk/om/mock/MkDocTest.java
+++ b/src/test/java/com/nerodesk/om/mock/MkDocTest.java
@@ -111,16 +111,21 @@ public final class MkDocTest {
 
     /**
      * MkDoc can throw IOException on delete.
-     * @throws IOException In case of error
+     * @throws IOException In case of delete failed.
      */
     @Test (expected = IOException.class)
     public void throwsIOExceptionOnDelete() throws IOException {
-        final File file = new File(this.folder.newFolder(), "exception");
-        FileUtils.touch(file);
-        IOUtils.copy(
-            IOUtils.toInputStream("hello, world!"),
-            new FileOutputStream(file)
-        );
+        final File file;
+        try {
+            file = new File(this.folder.newFolder(), "exception");
+            FileUtils.touch(file);
+            IOUtils.copy(
+                IOUtils.toInputStream("hello, world!"),
+                new FileOutputStream(file)
+            );
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
         new MkDoc(file, "", "").delete();
     }
 

--- a/src/test/java/com/nerodesk/om/mock/MkDocTest.java
+++ b/src/test/java/com/nerodesk/om/mock/MkDocTest.java
@@ -111,7 +111,7 @@ public final class MkDocTest {
 
     /**
      * MkDoc can throw IOException on delete.
-     * @throws IOException In case of delete failed.
+     * @throws IOException In case of File.delete failed.
      */
     @Test (expected = IOException.class)
     public void throwsIOExceptionOnDelete() throws IOException {

--- a/src/test/java/com/nerodesk/om/mock/MkDocTest.java
+++ b/src/test/java/com/nerodesk/om/mock/MkDocTest.java
@@ -34,12 +34,9 @@ import com.nerodesk.om.Doc;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
@@ -52,6 +49,10 @@ import org.junit.rules.TemporaryFolder;
  * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
  * @version $Id$
  * @since 0.3
+ * @todo 95:30min method MkDoc.delete throws IOException if File.delete
+ *  return false. Lets add unit test to check it. You need to find way
+ *  to return false in File.delete (maybe make file Read Only via
+ *  File.setReadOnly).
  */
 public final class MkDocTest {
     /**
@@ -107,26 +108,6 @@ public final class MkDocTest {
             file.exists(),
             Matchers.is(false)
         );
-    }
-
-    /**
-     * MkDoc can throw IOException on delete.
-     * @throws IOException In case of File.delete failed.
-     */
-    @Test (expected = IOException.class)
-    public void throwsIOExceptionOnDelete() throws IOException {
-        final File file;
-        try {
-            file = new File(this.folder.newFolder(), "exception");
-            FileUtils.touch(file);
-            IOUtils.copy(
-                IOUtils.toInputStream("try to delete me"),
-                new FileOutputStream(file)
-            );
-        } catch (IOException e) {
-            throw new IllegalStateException(e);
-        }
-        new MkDoc(file, "", "").delete();
     }
 
     /**


### PR DESCRIPTION
#95. `MkDoc.write` didn't close FileInputStream so MkDoc.delete couldn't delete temp file. Method `File.delete` returned false, but it was ignored. Test `TkDeleteTest` failed (problem was reproduced in Windows and OSX, for Windows - constantly).

Fix:
- Properly close FileInputStream
- Check `File.delete` result and throw IOException, it's more verbose.
