### PR TITLE
#243 added visibility to documents

### DIFF
--- a/src/main/java/com/nerodesk/om/Attributes.java
+++ b/src/main/java/com/nerodesk/om/Attributes.java
@@ -29,59 +29,49 @@
  */
 package com.nerodesk.om;
 
-import com.jcabi.aspects.Immutable;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.util.Date;
 
 /**
- * Document.
- *
- * @author Yegor Bugayenko (yegor@teamed.io)
+ * Document attributes.
+ * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
  * @version $Id$
- * @since 0.2
+ * @since 0.4
  */
-@Immutable
-public interface Doc {
-
+public interface Attributes {
     /**
-     * Does it exist?
-     * @return TRUE if exists
+     * Size of the document in bytes.
+     * @return Number of bytes
      * @throws IOException If fails
      */
-    boolean exists() throws IOException;
+    long size() throws IOException;
 
     /**
-     * Delete it (fails if the document is not mine).
+     * Mime type of the document.
+     * @return Mime type.
      * @throws IOException If fails
      */
-    void delete() throws IOException;
+    String type() throws IOException;
 
     /**
-     * Everybody who has access to this document.
-     * @return Friends
+     * Timestamp when the document was created.
+     * @return Date in UTC.
      * @throws IOException If fails
      */
-    Friends friends() throws IOException;
+    Date created() throws IOException;
 
     /**
-     * Read its entire content into this output stream.
-     * @param output Output stream
+     * Whether given document is public.
+     * @return True if it is public, false if it is private.
      * @throws IOException If fails
      */
-    void read(OutputStream output) throws IOException;
+    boolean visible() throws IOException;
 
     /**
-     * Write its entire content from this input stream.
-     * @param input Input stream
+     * Show given document to the public or hide it.
+     * @param shown True if document should be public, false otherwise
      * @throws IOException If fails
      */
-    void write(InputStream input) throws IOException;
+    void show(boolean shown) throws IOException;
 
-    /**
-     * Docuemnt attributes.
-     * @return Attributes
-     * @throws IOException If fails
-     */
-    Attributes attributes() throws IOException;
 }

--- a/src/main/java/com/nerodesk/om/SmallDoc.java
+++ b/src/main/java/com/nerodesk/om/SmallDoc.java
@@ -32,7 +32,6 @@ package com.nerodesk.om;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Date;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -85,21 +84,6 @@ public final class SmallDoc implements Doc {
     }
 
     @Override
-    public long size() throws IOException {
-        return this.decorated.size();
-    }
-
-    @Override
-    public String type() throws IOException {
-        return this.decorated.type();
-    }
-
-    @Override
-    public Date created() throws IOException {
-        return this.decorated.created();
-    }
-
-    @Override
     public Friends friends() throws IOException {
         return this.decorated.friends();
     }
@@ -123,5 +107,10 @@ public final class SmallDoc implements Doc {
                 ), exc
             );
         }
+    }
+
+    @Override
+    public Attributes attributes() throws IOException {
+        return this.decorated.attributes();
     }
 }

--- a/src/main/java/com/nerodesk/om/aws/AwsAttributes.java
+++ b/src/main/java/com/nerodesk/om/aws/AwsAttributes.java
@@ -27,61 +27,48 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.nerodesk.om;
+package com.nerodesk.om.aws;
 
-import com.jcabi.aspects.Immutable;
+import com.jcabi.aspects.Tv;
+import com.nerodesk.om.Attributes;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.util.Date;
+import lombok.EqualsAndHashCode;
 
 /**
- * Document.
+ * Aws based document attributes.
  *
- * @author Yegor Bugayenko (yegor@teamed.io)
+ * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
  * @version $Id$
- * @since 0.2
+ * @since 0.4
+ * @todo #243:30min Implement storage and retrieval of visible status of the
+ *  document, by implementing methods `visible` and `show` below. Don't forget
+ *  to test it first.
  */
-@Immutable
-public interface Doc {
+@EqualsAndHashCode
+public final class AwsAttributes implements Attributes {
+    @Override
+    public long size() throws IOException {
+        return Tv.MILLION;
+    }
 
-    /**
-     * Does it exist?
-     * @return TRUE if exists
-     * @throws IOException If fails
-     */
-    boolean exists() throws IOException;
+    @Override
+    public String type() throws IOException {
+        return "application/octet-stream";
+    }
 
-    /**
-     * Delete it (fails if the document is not mine).
-     * @throws IOException If fails
-     */
-    void delete() throws IOException;
+    @Override
+    public Date created() throws IOException {
+        return new Date();
+    }
 
-    /**
-     * Everybody who has access to this document.
-     * @return Friends
-     * @throws IOException If fails
-     */
-    Friends friends() throws IOException;
+    @Override
+    public boolean visible() throws IOException {
+        return true;
+    }
 
-    /**
-     * Read its entire content into this output stream.
-     * @param output Output stream
-     * @throws IOException If fails
-     */
-    void read(OutputStream output) throws IOException;
-
-    /**
-     * Write its entire content from this input stream.
-     * @param input Input stream
-     * @throws IOException If fails
-     */
-    void write(InputStream input) throws IOException;
-
-    /**
-     * Docuemnt attributes.
-     * @return Attributes
-     * @throws IOException If fails
-     */
-    Attributes attributes() throws IOException;
+    @Override
+    public void show(final boolean shown) throws IOException {
+        // do nothing
+    }
 }

--- a/src/main/java/com/nerodesk/om/aws/AwsDoc.java
+++ b/src/main/java/com/nerodesk/om/aws/AwsDoc.java
@@ -30,16 +30,15 @@
 package com.nerodesk.om.aws;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.jcabi.aspects.Tv;
 import com.jcabi.log.Logger;
 import com.jcabi.s3.Bucket;
 import com.jcabi.s3.Ocket;
+import com.nerodesk.om.Attributes;
 import com.nerodesk.om.Doc;
 import com.nerodesk.om.Friends;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Date;
 import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 
@@ -100,21 +99,6 @@ final class AwsDoc implements Doc {
     }
 
     @Override
-    public long size() throws IOException {
-        return Tv.MILLION;
-    }
-
-    @Override
-    public String type() throws IOException {
-        return "application/octet-stream";
-    }
-
-    @Override
-    public Date created() throws IOException {
-        return new Date();
-    }
-
-    @Override
     public Friends friends() {
         return new AwsFriends(this.bucket, this.user, this.label);
     }
@@ -139,6 +123,11 @@ final class AwsDoc implements Doc {
         }
         ocket.write(input, new ObjectMetadata());
         Logger.info(this, "%s written", ocket);
+    }
+
+    @Override
+    public Attributes attributes() throws IOException {
+        return new AwsAttributes();
     }
 
     /**

--- a/src/main/java/com/nerodesk/om/mock/MkAttributes.java
+++ b/src/main/java/com/nerodesk/om/mock/MkAttributes.java
@@ -27,61 +27,73 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.nerodesk.om;
+package com.nerodesk.om.mock;
 
-import com.jcabi.aspects.Immutable;
+import com.nerodesk.om.Attributes;
+import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Date;
+import org.apache.commons.io.FileUtils;
 
 /**
- * Document.
+ * Mock of document attributes.
  *
- * @author Yegor Bugayenko (yegor@teamed.io)
+ * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
  * @version $Id$
- * @since 0.2
+ * @since 0.4
  */
-@Immutable
-public interface Doc {
+public final class MkAttributes implements Attributes {
 
     /**
-     * Does it exist?
-     * @return TRUE if exists
-     * @throws IOException If fails
+     * File of document.
      */
-    boolean exists() throws IOException;
+    private final transient File file;
 
     /**
-     * Delete it (fails if the document is not mine).
-     * @throws IOException If fails
+     * Document shown to the public.
      */
-    void delete() throws IOException;
+    private transient boolean shown;
 
     /**
-     * Everybody who has access to this document.
-     * @return Friends
-     * @throws IOException If fails
+     * Constructor.
+     * @param fle File to use
      */
-    Friends friends() throws IOException;
+    public MkAttributes(final File fle) {
+        this.file = fle;
+    }
 
-    /**
-     * Read its entire content into this output stream.
-     * @param output Output stream
-     * @throws IOException If fails
-     */
-    void read(OutputStream output) throws IOException;
+    @Override
+    public long size() throws IOException {
+        return FileUtils.sizeOf(this.file);
+    }
 
-    /**
-     * Write its entire content from this input stream.
-     * @param input Input stream
-     * @throws IOException If fails
-     */
-    void write(InputStream input) throws IOException;
+    @Override
+    public String type() throws IOException {
+        String type = Files.probeContentType(this.file.toPath());
+        if (type == null) {
+            type = "unknown";
+        }
+        return type;
+    }
 
-    /**
-     * Docuemnt attributes.
-     * @return Attributes
-     * @throws IOException If fails
-     */
-    Attributes attributes() throws IOException;
+    @Override
+    public Date created() throws IOException {
+        return new Date(
+            Files.readAttributes(
+                this.file.toPath(), BasicFileAttributes.class
+            ).creationTime().toMillis()
+        );
+    }
+
+    @Override
+    public boolean visible() throws IOException {
+        return this.shown;
+    }
+
+    @Override
+    public void show(final boolean shwn) throws IOException {
+        this.shown = shwn;
+    }
 }

--- a/src/main/java/com/nerodesk/om/mock/MkDoc.java
+++ b/src/main/java/com/nerodesk/om/mock/MkDoc.java
@@ -30,6 +30,7 @@
 package com.nerodesk.om.mock;
 
 import com.jcabi.log.Logger;
+import com.nerodesk.om.Attributes;
 import com.nerodesk.om.Doc;
 import com.nerodesk.om.Friends;
 import java.io.File;
@@ -38,9 +39,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Date;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
@@ -68,6 +66,11 @@ public final class MkDoc implements Doc {
     private final transient String label;
 
     /**
+     * Document attributes.
+     */
+    private final transient Attributes attrs;
+
+    /**
      * Ctor.
      * @param file Directory
      * @param urn URN
@@ -77,6 +80,7 @@ public final class MkDoc implements Doc {
         this.dir = file;
         this.user = urn;
         this.label = name;
+        this.attrs = new MkAttributes(this.file());
     }
 
     @Override
@@ -90,29 +94,6 @@ public final class MkDoc implements Doc {
         if (!file.delete()) {
             throw new IOException(String.format("Failed to delete %s", file));
         }
-    }
-
-    @Override
-    public long size() throws IOException {
-        return FileUtils.sizeOf(this.file());
-    }
-
-    @Override
-    public String type() throws IOException {
-        String type = Files.probeContentType(this.file().toPath());
-        if (type == null) {
-            type = "unknown";
-        }
-        return type;
-    }
-
-    @Override
-    public Date created() throws IOException {
-        return new Date(
-            Files.readAttributes(
-                this.file().toPath(), BasicFileAttributes.class
-            ).creationTime().toMillis()
-        );
     }
 
     @Override
@@ -135,6 +116,11 @@ public final class MkDoc implements Doc {
             IOUtils.copy(input, output);
         }
         Logger.info(this, "%s saved", file);
+    }
+
+    @Override
+    public Attributes attributes() throws IOException {
+        return this.attrs;
     }
 
     /**

--- a/src/main/java/com/nerodesk/takes/TkDocs.java
+++ b/src/main/java/com/nerodesk/takes/TkDocs.java
@@ -29,6 +29,7 @@
  */
 package com.nerodesk.takes;
 
+import com.nerodesk.om.Attributes;
 import com.nerodesk.om.Base;
 import com.nerodesk.om.Doc;
 import com.nerodesk.om.Docs;
@@ -123,16 +124,17 @@ public final class TkDocs implements Take {
         final Request req) throws IOException {
         final Href home = new RqHref.Base(req).href()
             .path("doc").with("file", name);
+        final Attributes attrs = doc.attributes();
         return new XeAppend(
             "doc",
             new XeChain(
                 new XeDirectives(
                     new Directives()
                         .add("name").set(name).up()
-                        .add("size").set(Long.toString(doc.size())).up()
+                        .add("size").set(Long.toString(attrs.size())).up()
                         .add("created")
-                        .set(Long.toString(doc.created().getTime())).up()
-                        .add("type").set(doc.type()).up()
+                        .set(Long.toString(attrs.created().getTime())).up()
+                        .add("type").set(attrs.type()).up()
                         .add("name").set(name)
                 ),
                 new XeLink("read", home.path("read")),

--- a/src/main/java/com/nerodesk/takes/doc/TkSetVisibility.java
+++ b/src/main/java/com/nerodesk/takes/doc/TkSetVisibility.java
@@ -49,6 +49,10 @@ import org.takes.rs.RsWithStatus;
  *  is private or public. Note that we don't have this functionality in the Doc
  *  API yet, either, so you may want to start with a skeleton of that - use
  *  PDD to your advantage.
+ * @todo #243:30min Implement setting of document visibility using method
+ *  `show` from `Attributes`. Update docs.xsl and TkDocs with correct link to
+ *  this class. docs.xsl should also show the current state of document
+ *  public/private status (using `Attributes.visible` method).
  */
 public final class TkSetVisibility implements Take {
 

--- a/src/test/java/com/nerodesk/om/mock/MkAttributesTest.java
+++ b/src/test/java/com/nerodesk/om/mock/MkAttributesTest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2015, nerodesk.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the nerodesk.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.nerodesk.om.mock;
+
+import com.nerodesk.om.Attributes;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.TimeUnit;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for {@link MkAttributes}.
+ * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
+ * @version $Id$
+ * @since 0.4
+ */
+public final class MkAttributesTest {
+    /**
+     * Temporary folder.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    @Rule
+    public final transient TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * MkAttributes can guess content type.
+     * @throws IOException In case of error
+     */
+    @Test
+    public void guessesContentType() throws IOException {
+        final File file = new File(this.folder.newFolder(), "findout");
+        final String content = "Ordinary text content.";
+        final Attributes attrs = new MkAttributes(file);
+        Files.write(
+            file.toPath(),
+            content.getBytes(StandardCharsets.UTF_8),
+            StandardOpenOption.CREATE
+        );
+        MatcherAssert.assertThat(
+            attrs.type(),
+            Matchers.notNullValue()
+        );
+    }
+
+    /**
+     * MkAttributes can count bytes in document.
+     * @throws IOException In case of error
+     */
+    @Test
+    public void countsBytesInDocument() throws IOException {
+        final File file = new File(this.folder.newFolder(), "size");
+        final String content = "count me";
+        final Attributes attrs = new MkAttributes(file);
+        Files.write(
+            file.toPath(),
+            content.getBytes(StandardCharsets.UTF_8),
+            StandardOpenOption.CREATE
+        );
+        MatcherAssert.assertThat(
+            attrs.size(),
+            Matchers.equalTo((long) content.length())
+        );
+    }
+
+    /**
+     * MkAttributes can retrieve file creation time.
+     * @throws IOException In case of error
+     */
+    @Test
+    public void retrievesFileCreationTime() throws IOException {
+        final File file = new File(this.folder.newFolder(), "time");
+        final String content = "some content";
+        final long before = System.currentTimeMillis();
+        final Attributes attrs = new MkAttributes(file);
+        Files.write(
+            file.toPath(),
+            content.getBytes(StandardCharsets.UTF_8),
+            StandardOpenOption.CREATE
+        );
+        final long after = System.currentTimeMillis();
+        MatcherAssert.assertThat(
+            TimeUnit.MILLISECONDS.toSeconds(attrs.created().getTime()),
+            Matchers.allOf(
+                Matchers.greaterThanOrEqualTo(
+                    TimeUnit.MILLISECONDS.toSeconds(before)
+                ),
+                Matchers.lessThanOrEqualTo(
+                    TimeUnit.MILLISECONDS.toSeconds(after)
+                )
+            )
+        );
+    }
+
+    /**
+     * MkAttributes can set visibility.
+     * @throws IOException In case of error
+     */
+    @Test
+    public void setsVisibility() throws IOException {
+        final File file = new File(this.folder.newFolder(), "visibility");
+        final String content = "text content.";
+        final Attributes attrs = new MkAttributes(file);
+        Files.write(
+            file.toPath(),
+            content.getBytes(StandardCharsets.UTF_8),
+            StandardOpenOption.CREATE
+        );
+        MatcherAssert.assertThat(
+            attrs.visible(),
+            Matchers.is(false)
+        );
+        attrs.show(true);
+        MatcherAssert.assertThat(
+            attrs.visible(),
+            Matchers.is(true)
+        );
+    }
+}

--- a/src/test/java/com/nerodesk/om/mock/MkDocTest.java
+++ b/src/test/java/com/nerodesk/om/mock/MkDocTest.java
@@ -30,13 +30,11 @@
 package com.nerodesk.om.mock;
 
 import com.google.common.io.Files;
-import com.nerodesk.om.Doc;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
@@ -141,69 +139,6 @@ public final class MkDocTest {
         MatcherAssert.assertThat(
             Files.toString(file, StandardCharsets.UTF_8),
             Matchers.equalTo(content)
-        );
-    }
-
-    /**
-     * MkDoc can guess content type.
-     * @throws IOException In case of error
-     */
-    @Test
-    public void guessesContentType() throws IOException {
-        final File file = new File(this.folder.newFolder(), "findout");
-        final String content = "Ordinary text content.";
-        final Doc doc = new MkDoc(file, "", "");
-        doc.write(
-            new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
-        );
-        MatcherAssert.assertThat(
-            doc.type(),
-            Matchers.notNullValue()
-        );
-    }
-
-    /**
-     * MkDoc can count bytes in document.
-     * @throws IOException In case of error
-     */
-    @Test
-    public void countsBytesInDocument() throws IOException {
-        final File file = new File(this.folder.newFolder(), "size");
-        final String content = "count me";
-        final Doc doc = new MkDoc(file, "", "");
-        doc.write(
-            new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
-        );
-        MatcherAssert.assertThat(
-            doc.size(),
-            Matchers.equalTo((long) content.length())
-        );
-    }
-
-    /**
-     * MkDoc can retrieve file creation time.
-     * @throws IOException In case of error
-     */
-    @Test
-    public void retrievesFileCreationTime() throws IOException {
-        final File file = new File(this.folder.newFolder(), "time");
-        final String content = "some content";
-        final long before = System.currentTimeMillis();
-        final Doc doc = new MkDoc(file, "", "");
-        doc.write(
-            new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
-        );
-        final long after = System.currentTimeMillis();
-        MatcherAssert.assertThat(
-            TimeUnit.MILLISECONDS.toSeconds(doc.created().getTime()),
-            Matchers.allOf(
-                Matchers.greaterThanOrEqualTo(
-                    TimeUnit.MILLISECONDS.toSeconds(before)
-                ),
-                Matchers.lessThanOrEqualTo(
-                    TimeUnit.MILLISECONDS.toSeconds(after)
-                )
-            )
         );
     }
 }


### PR DESCRIPTION
#243

I've refactored `Doc` to have a separate class for attributes and implemented visibility modifier there. I've implemented `MkAttributes` and added todo for `AwsAttributes` implementation. Added todo for modification of the attribute from the web page, and for displaying the attribute state.
