### PR TITLE
#253 corrected size parameter

### DIFF
--- a/src/main/java/com/nerodesk/om/mock/MkDoc.java
+++ b/src/main/java/com/nerodesk/om/mock/MkDoc.java
@@ -115,7 +115,8 @@ public final class MkDoc implements Doc {
         final File file = this.file();
         FileUtils.touch(file);
         try (final FileOutputStream output = new FileOutputStream(file)) {
-            IOUtils.copy(input, output);
+            final int count = IOUtils.copy(input, output);
+            IOUtils.write(new byte[(int) size - count], output);
         }
         Logger.info(this, "%s saved", file);
     }

--- a/src/main/java/com/nerodesk/takes/doc/TkWrite.java
+++ b/src/main/java/com/nerodesk/takes/doc/TkWrite.java
@@ -34,13 +34,12 @@ import com.nerodesk.om.Doc;
 import com.nerodesk.takes.RqDisposition;
 import com.nerodesk.takes.RqUser;
 import java.io.IOException;
-import java.util.Iterator;
+import java.io.InputStream;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
-import org.takes.rq.RqHeaders;
 import org.takes.rq.RqMultipart;
 
 /**
@@ -75,15 +74,8 @@ final class TkWrite implements Take {
         final Doc doc = new RqUser(req, this.base).user().docs().doc(
             new RqDisposition(part).filename()
         );
-        final Iterator<String> header = new RqHeaders(multi)
-            .header("Content-Length").iterator();
-        final long size;
-        if (header.hasNext()) {
-            size = Long.parseLong(header.next());
-        } else {
-            size = 0;
-        }
-        doc.write(part.body(), size);
+        final InputStream body = part.body();
+        doc.write(body, body.available());
         return new RsForward(new RsFlash("file uploaded"));
     }
 

--- a/src/test/java/com/nerodesk/takes/doc/TkWriteTest.java
+++ b/src/test/java/com/nerodesk/takes/doc/TkWriteTest.java
@@ -60,6 +60,7 @@ public final class TkWriteTest {
         final Base base = new MkBase();
         final User user = base.user("urn:test:1");
         final String file = "hey.txt";
+        final String content = "hello, world!";
         final String body = Joiner.on("\r\n").join(
             " --AaB03x",
             "Content-Disposition: form-data; name=\"name\"",
@@ -73,7 +74,7 @@ public final class TkWriteTest {
             ),
             "Content-Transfer-Encoding: utf-8",
             "",
-            "hello, world!",
+            content,
             "--AaB03x--"
         );
         MatcherAssert.assertThat(
@@ -81,8 +82,13 @@ public final class TkWriteTest {
                 new TkWrite(base).act(
                     new RqWithTester(
                         new RqWithHeader(
-                            new RqFake("POST", "/", body),
-                            "Content-Type: multipart/form-data; boundary=AaB03x"
+                            new RqWithHeader(
+                                new RqFake("POST", "/", body),
+                                "Content-Type",
+                                "multipart/form-data; boundary=AaB03x"
+                            ),
+                            "Content-length",
+                            String.valueOf(body.length())
                         )
                     )
                 )
@@ -93,7 +99,7 @@ public final class TkWriteTest {
         user.docs().doc(file).read(baos);
         MatcherAssert.assertThat(
             new String(baos.toByteArray()),
-            Matchers.endsWith("world!")
+            Matchers.equalTo(content)
         );
     }
 


### PR DESCRIPTION
#253
- using `body.available()` instead of `Content-length` header for file size
- updated MkDoc to create a file with the size provided, even if stream is shorter - acts more like `AwsDoc`
- corrected `TkWrite` test to take into account the `size` parameter
- tested it with S3 and it correctly uploads files (without any warnings)
