### PR TITLE
#258 re-designed to read bitly credentials from manifest.mf

### DIFF
--- a/src/main/java/com/nerodesk/om/aws/AwsDoc.java
+++ b/src/main/java/com/nerodesk/om/aws/AwsDoc.java
@@ -159,15 +159,9 @@ final class AwsDoc implements Doc {
      * @return Key
      */
     private Ocket ocket() {
-        return this.bucket.ocket(this.ocketKey());
-    }
-
-    /**
-     * Ocket key.
-     * @return Ocket key.
-     */
-    private String ocketKey() {
-        return String.format("%s/%s", this.user, this.label);
+        return this.bucket.ocket(
+            String.format("%s/%s", this.user, this.label)
+        );
     }
 
 }

--- a/src/main/java/com/nerodesk/om/aws/AwsDoc.java
+++ b/src/main/java/com/nerodesk/om/aws/AwsDoc.java
@@ -31,6 +31,7 @@ package com.nerodesk.om.aws;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.jcabi.log.Logger;
+import com.jcabi.manifests.Manifests;
 import com.jcabi.s3.Bucket;
 import com.jcabi.s3.Ocket;
 import com.nerodesk.om.Attributes;
@@ -134,19 +135,15 @@ final class AwsDoc implements Doc {
 
     @Override
     public String shortUrl() {
-        // @checkstyle MethodBodyCommentsCheck (5 lines)
-        // @todo #212:30min Implementation has to be replaced with the correct
-        //  one using the correct authentication for the bit.ly data and the
-        //  correctly generated url to the actual document. After that fix and
-        //  un-ignore the test `com.nerodesk.om.aws.AwsDocTest.shortenUrl()` to
-        //  match some real data.
         return Bitly
-            .as("nerodesk", "R_95c4f6c85c67498bba37a73872577410")
+            .as(
+                Manifests.read("Nerodesk-BitlyId"),
+                Manifests.read("Nerodesk-BitlyKey")
+        )
             .call(
                 Bitly.shorten(
-                    new Href("http://beta.nerodesk.com/doc/read").with(
-                        "file", this.label
-                    ).toString()
+                    new Href("http://beta.nerodesk.com/doc/read")
+                        .with("file", this.label).toString()
                 )
             )
             .getShortUrl();
@@ -158,13 +155,19 @@ final class AwsDoc implements Doc {
     }
 
     /**
-     * Ocket key.
+     * Ocket.
      * @return Key
      */
     private Ocket ocket() {
-        return this.bucket.ocket(
-            String.format("%s/%s", this.user, this.label)
-        );
+        return this.bucket.ocket(this.ocketKey());
+    }
+
+    /**
+     * Ocket key.
+     * @return Ocket key.
+     */
+    private String ocketKey() {
+        return String.format("%s/%s", this.user, this.label);
     }
 
 }

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -14,3 +14,5 @@ Nerodesk-SecurityKey: ${security.key}
 Nerodesk-AwsKey: ${aws.key}
 Nerodesk-AwsSecret: ${aws.secret}
 Nerodesk-Bucket: ${bucket}
+Nerodesk-BitlyId: ${bitly.id}
+Nerodesk-BitlyKey: ${bitly.key}

--- a/src/test/java/com/nerodesk/om/aws/AwsDocTest.java
+++ b/src/test/java/com/nerodesk/om/aws/AwsDocTest.java
@@ -30,6 +30,7 @@
 package com.nerodesk.om.aws;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.jcabi.manifests.Manifests;
 import com.jcabi.s3.Bucket;
 import com.jcabi.s3.Ocket;
 import com.jcabi.s3.mock.MkBucket;
@@ -42,7 +43,6 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
@@ -139,13 +139,17 @@ public final class AwsDocTest {
      * @throws IOException If unsuccessful.
      */
     @Test
-    @Ignore
     public void shortenUrl() throws IOException {
+        Manifests.DEFAULT.put("Nerodesk-BitlyId", "nerodesk");
+        Manifests.DEFAULT.put(
+            "Nerodesk-BitlyKey",
+            "R_95c4f6c85c67498bba37a73872577410"
+        );
         final String label = "shorten";
         final AwsDoc doc = this.createDoc(label, label);
         MatcherAssert.assertThat(
             doc.shortUrl(),
-            Matchers.equalTo(doc.shortUrl())
+            Matchers.equalTo("http://bit.ly/1GgY5gX")
         );
     }
 


### PR DESCRIPTION
#258 re-designed to read bitly credentials from `Manifest.MF`
