### PR TITLE
#278 Visibility in MkAttributes as file metadata

### DIFF
--- a/src/main/java/com/nerodesk/om/mock/MkAttributes.java
+++ b/src/main/java/com/nerodesk/om/mock/MkAttributes.java
@@ -92,23 +92,19 @@ public final class MkAttributes implements Attributes {
     @Override
     public boolean visible() throws IOException {
         final boolean shown;
-        if (this.file.exists()) {
-            final UserDefinedFileAttributeView view =
-                Files.getFileAttributeView(
-                    this.file.toPath(), UserDefinedFileAttributeView.class
-                );
-            if (view.list().contains(MkAttributes.VISIBILITY)) {
-                final ByteBuffer buf = ByteBuffer.allocate(
-                    view.size(MkAttributes.VISIBILITY)
-                );
-                view.read(MkAttributes.VISIBILITY, buf);
-                buf.flip();
-                shown = Boolean.valueOf(
-                    StandardCharsets.UTF_8.decode(buf).toString()
-                );
-            } else {
-                shown = false;
-            }
+        final UserDefinedFileAttributeView view =
+            Files.getFileAttributeView(
+                this.file.toPath(), UserDefinedFileAttributeView.class
+            );
+        if (view.list().contains(MkAttributes.VISIBILITY)) {
+            final ByteBuffer buf = ByteBuffer.allocate(
+                view.size(MkAttributes.VISIBILITY)
+            );
+            view.read(MkAttributes.VISIBILITY, buf);
+            buf.flip();
+            shown = Boolean.valueOf(
+                StandardCharsets.UTF_8.decode(buf).toString()
+            );
         } else {
             shown = false;
         }
@@ -117,13 +113,11 @@ public final class MkAttributes implements Attributes {
 
     @Override
     public void show(final boolean shwn) throws IOException {
-        if (this.file.exists()) {
-            Files.getFileAttributeView(
-                this.file.toPath(), UserDefinedFileAttributeView.class
-            ).write(
-                    MkAttributes.VISIBILITY,
-                    StandardCharsets.UTF_8.encode(String.valueOf(shwn))
-                );
-        }
+        Files.getFileAttributeView(
+            this.file.toPath(), UserDefinedFileAttributeView.class
+        ).write(
+                MkAttributes.VISIBILITY,
+                StandardCharsets.UTF_8.encode(String.valueOf(shwn))
+            );
     }
 }

--- a/src/main/java/com/nerodesk/om/mock/MkAttributes.java
+++ b/src/main/java/com/nerodesk/om/mock/MkAttributes.java
@@ -29,11 +29,11 @@
  */
 package com.nerodesk.om.mock;
 
-import com.google.common.base.Charsets;
 import com.nerodesk.om.Attributes;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.UserDefinedFileAttributeView;
@@ -103,7 +103,9 @@ public final class MkAttributes implements Attributes {
                 );
                 view.read(MkAttributes.VISIBILITY, buf);
                 buf.flip();
-                shown = Boolean.valueOf(Charsets.UTF_8.decode(buf).toString());
+                shown = Boolean.valueOf(
+                    StandardCharsets.UTF_8.decode(buf).toString()
+                );
             } else {
                 shown = false;
             }
@@ -120,7 +122,7 @@ public final class MkAttributes implements Attributes {
                 this.file.toPath(), UserDefinedFileAttributeView.class
             ).write(
                     MkAttributes.VISIBILITY,
-                    Charsets.UTF_8.encode(String.valueOf(shwn))
+                    StandardCharsets.UTF_8.encode(String.valueOf(shwn))
                 );
         }
     }

--- a/src/test/java/com/nerodesk/om/mock/MkAttributesTest.java
+++ b/src/test/java/com/nerodesk/om/mock/MkAttributesTest.java
@@ -133,12 +133,12 @@ public final class MkAttributesTest {
     public void setsVisibility() throws IOException {
         final File file = new File(this.folder.newFolder(), "visibility");
         final String content = "text content.";
-        final Attributes attrs = new MkAttributes(file);
         Files.write(
             file.toPath(),
             content.getBytes(StandardCharsets.UTF_8),
             StandardOpenOption.CREATE
         );
+        final Attributes attrs = new MkAttributes(file);
         MatcherAssert.assertThat(
             attrs.visible(),
             Matchers.is(false)

--- a/src/test/java/com/nerodesk/om/mock/MkAttributesTest.java
+++ b/src/test/java/com/nerodesk/om/mock/MkAttributesTest.java
@@ -149,4 +149,26 @@ public final class MkAttributesTest {
             Matchers.is(true)
         );
     }
+
+    /**
+     * MkAttributes can throw an exception if visibility is set for a
+     * nonexistent file.
+     * @throws Exception In case of error
+     */
+    @Test(expected = IOException.class)
+    public void throwsExceptionIfVisibilitySetForNonexistentFile()
+        throws Exception {
+        new MkAttributes(new File("nonexistent-set-visibility")).show(true);
+    }
+
+    /**
+     * MkAttributes can throw an exception if visible is called for a
+     * nonexistent file.
+     * @throws Exception In case of error
+     */
+    @Test(expected = IOException.class)
+    public void throwsExceptionIfVisibileCalledNonexistentFile()
+        throws Exception {
+        new MkAttributes(new File("nonexistent-call-visible")).visible();
+    }
 }

--- a/src/test/java/com/nerodesk/takes/doc/TkSetVisibilityTest.java
+++ b/src/test/java/com/nerodesk/takes/doc/TkSetVisibilityTest.java
@@ -29,14 +29,16 @@
  */
 package com.nerodesk.takes.doc;
 
+import com.google.common.io.Files;
 import com.nerodesk.om.Base;
 import com.nerodesk.om.Doc;
 import com.nerodesk.om.Docs;
 import com.nerodesk.om.mock.MkBase;
 import com.nerodesk.takes.RqWithTester;
+import java.io.File;
+import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.takes.misc.Href;
 import org.takes.rq.RqFake;
@@ -92,19 +94,18 @@ public final class TkSetVisibilityTest {
     /**
      * TkSetVisibility can set a file's visibility.
      * @throws Exception If something goes wrong
-     * @todo #255:30min Make visibility functionality in MkAttributes be a
-     *  function of the underlying file instead of a boolean field. This is
-     *  necessary in order for different instances of MkDoc which point to the
-     *  same underlying file to see the same visibility status. Once this is
-     *  done, un-ignore the test below.
      */
     @Test
-    @Ignore
     public void setsVisibility() throws Exception {
-        final Base base = new MkBase();
+        final File dir = Files.createTempDir();
+        final Base base = new MkBase(dir);
         final String name = "setsVisibility.txt";
         final Docs docs = base.user("urn:test:1").docs();
         final Doc doc = docs.doc(name);
+        final File file = dir.toPath().resolve(Paths.get("urn/test/1", name))
+            .toFile();
+        file.getParentFile().mkdirs();
+        file.createNewFile();
         MatcherAssert.assertThat(
             doc.attributes().visible(),
             Matchers.is(false)

--- a/src/test/java/com/nerodesk/takes/doc/TkSetVisibilityTest.java
+++ b/src/test/java/com/nerodesk/takes/doc/TkSetVisibilityTest.java
@@ -29,14 +29,11 @@
  */
 package com.nerodesk.takes.doc;
 
-import com.google.common.io.Files;
 import com.nerodesk.om.Base;
 import com.nerodesk.om.Doc;
-import com.nerodesk.om.Docs;
 import com.nerodesk.om.mock.MkBase;
 import com.nerodesk.takes.RqWithTester;
-import java.io.File;
-import java.nio.file.Paths;
+import java.io.ByteArrayInputStream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -97,15 +94,10 @@ public final class TkSetVisibilityTest {
      */
     @Test
     public void setsVisibility() throws Exception {
-        final File dir = Files.createTempDir();
-        final Base base = new MkBase(dir);
+        final Base base = new MkBase();
         final String name = "setsVisibility.txt";
-        final Docs docs = base.user("urn:test:1").docs();
-        final Doc doc = docs.doc(name);
-        final File file = dir.toPath().resolve(Paths.get("urn/test/1", name))
-            .toFile();
-        file.getParentFile().mkdirs();
-        file.createNewFile();
+        final Doc doc = base.user("urn:test:1").docs().doc(name);
+        doc.write(new ByteArrayInputStream(new byte[1]), 1);
         MatcherAssert.assertThat(
             doc.attributes().visible(),
             Matchers.is(false)

--- a/src/test/java/com/nerodesk/takes/doc/TkSetVisibilityTest.java
+++ b/src/test/java/com/nerodesk/takes/doc/TkSetVisibilityTest.java
@@ -73,6 +73,9 @@ public final class TkSetVisibilityTest {
     public void returnsResponse() throws Exception {
         final Base base = new MkBase();
         final String name = "returnsResponse.txt";
+        // @checkstyle MultipleStringLiterals (1 line)
+        base.user("urn:test:1").docs().doc(name)
+            .write(new ByteArrayInputStream(new byte[0]), 0);
         MatcherAssert.assertThat(
             new TkSetVisibility(base).act(
                 new RqWithTester(


### PR DESCRIPTION
#278:
- `visible` flag in `MkAttributes` is now based on custom metadata
- `MkAttributesTest.setVisibility()` revised slightly, the file had to exist before the metadata can be set. Otherwise, it will throw an `IOException`.
- `TkSetVisibilityTest.setsVisibility()` revised heavily and enabled.
