### PR TITLE
#211 changed the format date to ISO 8601

### DIFF
--- a/src/main/java/com/nerodesk/takes/TkDocs.java
+++ b/src/main/java/com/nerodesk/takes/TkDocs.java
@@ -35,6 +35,8 @@ import com.nerodesk.om.Doc;
 import com.nerodesk.om.Docs;
 import com.nerodesk.om.User;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
@@ -126,6 +128,10 @@ public final class TkDocs implements Take {
         final Href home = new RqHref.Base(req).href()
             .path("doc").with("file", name);
         final Attributes attrs = doc.attributes();
+        final SimpleDateFormat fmt = new SimpleDateFormat(
+            "yyyy-MM-dd'T'HH:mm:ssXXX",
+            Locale.US
+        );
         return new XeAppend(
             "doc",
             new XeChain(
@@ -134,7 +140,7 @@ public final class TkDocs implements Take {
                         .add("name").set(name).up()
                         .add("size").set(Long.toString(attrs.size())).up()
                         .add("created")
-                        .set(Long.toString(attrs.created().getTime())).up()
+                        .set(fmt.format(attrs.created().getTime())).up()
                         .add("type").set(attrs.type()).up()
                         .add("name").set(name)
                 ),

--- a/src/main/xsl/docs.xsl
+++ b/src/main/xsl/docs.xsl
@@ -105,12 +105,6 @@
                      </xsl:when>
                     </xsl:choose>
                     <xsl:text>created on </xsl:text>
-                    <!--
-                    @todo #101:30min Creation date of document should be displayed using
-                     ISO_8601 combined date time and timezone
-                     (e.g. 2007-04-05T12:30-02:00). Right now it is just a unix
-                     timestamp.
-                    -->
                     <xsl:value-of select="created"/>
                 </small>
                 <small>

--- a/src/test/java/com/nerodesk/takes/TkDocsTest.java
+++ b/src/test/java/com/nerodesk/takes/TkDocsTest.java
@@ -36,8 +36,11 @@ import com.nerodesk.om.User;
 import com.nerodesk.om.mock.MkBase;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.takes.facets.auth.Identity;
 import org.takes.facets.auth.TkAuth;
@@ -176,6 +179,43 @@ public final class TkDocsTest {
                     // @checkstyle LineLength (1 line)
                     "//xhtml:form[@action='http://www.example.com/doc/add-friend?file=%s']",
                     file
+                )
+            )
+        );
+    }
+
+    /**
+     * TkDocs can format date.
+     * @throws IOException In case of error
+     */
+    @Test
+    public void formatsDate() throws IOException {
+        final Base base = new MkBase();
+        final String file = "test4.txt";
+        final Doc doc = base.user(TkDocsTest.FAKE_URN).docs().doc(file);
+        final byte[] bytes = "hey!".getBytes();
+        doc.write(new ByteArrayInputStream(bytes), bytes.length);
+        MatcherAssert.assertThat(
+            IOUtils.toString(
+                new RsXSLT(
+                    new TkDocs(base).act(
+                        new RqWithHeader(
+                            new RqFake(),
+                            TkAuth.class.getSimpleName(),
+                            new String(
+                                new CcPlain().encode(
+                                    new Identity.Simple(TkDocsTest.FAKE_URN)
+                                )
+                            )
+                        )
+                    )
+                ).body()
+            ),
+            Matchers.containsString(
+                String.format(
+                    "created on %s",
+                    new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.US)
+                        .format(doc.attributes().created())
                 )
             )
         );


### PR DESCRIPTION
For #211 
- Changed date format to  ISO_8601 according the puzzle descripton. Since XSL  is version 1.0 so we can not use the native XSL date formatting. So I formated the date during XML building. The SimpleDateFormat variable used to avoid the quilice complains. Qulice  becomes a bit crasy if to check complex fluent expressions
- created the unit test
