### PR TITLE
#280 bit.ly integration requires cache for latency improvement

### DIFF
--- a/src/main/java/com/nerodesk/om/aws/AwsDocs.java
+++ b/src/main/java/com/nerodesk/om/aws/AwsDocs.java
@@ -90,11 +90,11 @@ final class AwsDocs implements Docs {
 
     @Override
     public Doc doc(final String doc) {
-        return new SmallDoc(
-            new CdShortUrl(
-                new AwsDoc(this.bucket, this.user, doc),
-            // @checkstyle MagicNumber (1 line)
-            250_000_000L
+        return new SafeDoc(
+            new SmallDoc(
+                new CdShortUrl(new AwsDoc(this.bucket, this.user, doc)),
+                // @checkstyle MagicNumber (1 line))
+                250_000_000L
             )
         );
     }

--- a/src/main/java/com/nerodesk/om/aws/AwsDocs.java
+++ b/src/main/java/com/nerodesk/om/aws/AwsDocs.java
@@ -89,10 +89,12 @@ final class AwsDocs implements Docs {
 
     @Override
     public Doc doc(final String doc) {
-        return new SmallDoc(
-            new AwsDoc(this.bucket, this.user, doc),
-            // @checkstyle MagicNumber (1 line)
-            250_000_000L
+        return new CdShortUrl(
+            new SmallDoc(
+                new AwsDoc(this.bucket, this.user, doc),
+                // @checkstyle MagicNumber (1 line)
+                250_000_000L
+            )
         );
     }
 

--- a/src/main/java/com/nerodesk/om/aws/CdShortUrl.java
+++ b/src/main/java/com/nerodesk/om/aws/CdShortUrl.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2015, nerodesk.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the nerodesk.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.nerodesk.om.aws;
+
+import com.jcabi.aspects.Cacheable;
+import com.jcabi.aspects.Tv;
+import com.nerodesk.om.Attributes;
+import com.nerodesk.om.Doc;
+import com.nerodesk.om.Friends;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.TimeUnit;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Decorator for {@link Doc} which cache short url..
+ *
+ * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
+ * @version $Id$
+ * @since 0.3.30
+ */
+@EqualsAndHashCode
+public final class CdShortUrl implements Doc {
+    /**
+     * Decorated.
+     */
+    private final transient Doc decorated;
+
+    /**
+     * Constructor.
+     * @param doc Doc to be decorated
+     */
+    public CdShortUrl(final Doc doc) {
+        this.decorated = doc;
+    }
+
+    @Override
+    public boolean exists() throws IOException {
+        return this.decorated.exists();
+    }
+
+    @Override
+    public void delete() throws IOException {
+        this.decorated.delete();
+    }
+
+    @Override
+    public Friends friends() throws IOException {
+        return this.decorated.friends();
+    }
+
+    @Override
+    public void read(final OutputStream output) throws IOException {
+        this.decorated.read(output);
+    }
+
+    @Override
+    public void write(final InputStream input, final long size)
+        throws IOException {
+        this.decorated.write(input, size);
+    }
+
+    @Override
+    @Cacheable(lifetime = Tv.THREE, unit = TimeUnit.HOURS)
+    public String shortUrl() {
+        return this.decorated.shortUrl();
+    }
+
+    @Override
+    public Attributes attributes() throws IOException {
+        return this.decorated.attributes();
+    }
+}

--- a/src/test/java/com/nerodesk/om/aws/CdShortUrlTest.java
+++ b/src/test/java/com/nerodesk/om/aws/CdShortUrlTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2015, nerodesk.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the nerodesk.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.nerodesk.om.aws;
+
+import com.jcabi.manifests.Manifests;
+import com.jcabi.s3.Bucket;
+import com.jcabi.s3.mock.MkBucket;
+import com.nerodesk.om.Doc;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for {@link CdShortUrl}.
+ *
+ * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
+ * @version $Id$
+ * @since 0.3.30
+ */
+public final class CdShortUrlTest {
+    /**
+     * CdShortUrl can shorten document URL.
+     * @throws IOException If unsuccessful.
+     */
+    @Test
+    public void shortenUrl() throws IOException {
+        Manifests.DEFAULT.put("Nerodesk-BitlyId", "nerodesk");
+        Manifests.DEFAULT.put(
+            "Nerodesk-BitlyKey",
+            "R_95c4f6c85c67498bba37a73872577410"
+        );
+        final String label = "shorten";
+        final CdShortUrl doc = new CdShortUrl(this.createDoc(label, label));
+        MatcherAssert.assertThat(
+            doc.shortUrl(),
+            Matchers.equalTo("http://bit.ly/1GgY5gX")
+        );
+    }
+
+    /**
+     * Constructs a mock bucket.
+     * @param name Bucket name.
+     * @throws IOException In case of failure.
+     * @return The mock bucket.
+     */
+    private MkBucket mockBucket(final String name) throws IOException {
+        final TemporaryFolder folder = new TemporaryFolder();
+        folder.create();
+        return new MkBucket(folder.getRoot(), name);
+    }
+
+    /**
+     * Creates an AwsDoc with given contents inside of a mock bucket .
+     * @param name Doc name.
+     * @param contents Doc contents.
+     * @return The new AwsDoc.
+     * @throws IOException In case of failure.
+     */
+    private Doc createDoc(final String name, final String contents)
+        throws IOException {
+        final Bucket bucket = this.mockBucket(name);
+        final AwsDoc doc = new AwsDoc(bucket, "", name);
+        doc.write(
+            new ByteArrayInputStream(contents.getBytes()),
+            contents.getBytes().length
+        );
+        return doc;
+    }
+}

--- a/src/test/java/com/nerodesk/om/aws/CdShortUrlTest.java
+++ b/src/test/java/com/nerodesk/om/aws/CdShortUrlTest.java
@@ -29,16 +29,15 @@
  */
 package com.nerodesk.om.aws;
 
-import com.jcabi.manifests.Manifests;
-import com.jcabi.s3.Bucket;
-import com.jcabi.s3.mock.MkBucket;
+import com.nerodesk.om.Attributes;
 import com.nerodesk.om.Doc;
-import java.io.ByteArrayInputStream;
+import com.nerodesk.om.Friends;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 /**
  * Tests for {@link CdShortUrl}.
@@ -54,46 +53,48 @@ public final class CdShortUrlTest {
      */
     @Test
     public void shortenUrl() throws IOException {
-        Manifests.DEFAULT.put("Nerodesk-BitlyId", "nerodesk");
-        Manifests.DEFAULT.put(
-            "Nerodesk-BitlyKey",
-            "R_95c4f6c85c67498bba37a73872577410"
+        final String url = "http://bit.ly/CdShort";
+        final Doc doc = new CdShortUrl(
+            // @checkstyle AnonInnerLengthCheck (1 lines)
+            new Doc() {
+                @Override
+                public boolean exists() throws IOException {
+                    return false;
+                }
+                @Override
+                public void delete() throws IOException {
+                    assert 1 != 0;
+                }
+                @Override
+                public Friends friends() throws IOException {
+                    return null;
+                }
+                @Override
+                public void read(final OutputStream output) throws IOException {
+                    output.close();
+                }
+                @Override
+                public void write(final InputStream input, final long size)
+                    throws IOException {
+                    input.close();
+                }
+                @Override
+                public String shortUrl() {
+                    return url;
+                }
+                @Override
+                public Attributes attributes() throws IOException {
+                    return null;
+                }
+            }
         );
-        final String label = "shorten";
-        final CdShortUrl doc = new CdShortUrl(this.createDoc(label, label));
         MatcherAssert.assertThat(
             doc.shortUrl(),
-            Matchers.equalTo("http://bit.ly/1GgY5gX")
+            Matchers.equalTo(url)
         );
-    }
-
-    /**
-     * Constructs a mock bucket.
-     * @param name Bucket name.
-     * @throws IOException In case of failure.
-     * @return The mock bucket.
-     */
-    private MkBucket mockBucket(final String name) throws IOException {
-        final TemporaryFolder folder = new TemporaryFolder();
-        folder.create();
-        return new MkBucket(folder.getRoot(), name);
-    }
-
-    /**
-     * Creates an AwsDoc with given contents inside of a mock bucket .
-     * @param name Doc name.
-     * @param contents Doc contents.
-     * @return The new AwsDoc.
-     * @throws IOException In case of failure.
-     */
-    private Doc createDoc(final String name, final String contents)
-        throws IOException {
-        final Bucket bucket = this.mockBucket(name);
-        final AwsDoc doc = new AwsDoc(bucket, "", name);
-        doc.write(
-            new ByteArrayInputStream(contents.getBytes()),
-            contents.getBytes().length
+        MatcherAssert.assertThat(
+            doc.shortUrl(),
+            Matchers.equalTo(url)
         );
-        return doc;
     }
 }

--- a/src/test/java/com/nerodesk/om/aws/CdShortUrlTest.java
+++ b/src/test/java/com/nerodesk/om/aws/CdShortUrlTest.java
@@ -29,15 +29,12 @@
  */
 package com.nerodesk.om.aws;
 
-import com.nerodesk.om.Attributes;
 import com.nerodesk.om.Doc;
-import com.nerodesk.om.Friends;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * Tests for {@link CdShortUrl}.
@@ -53,48 +50,18 @@ public final class CdShortUrlTest {
      */
     @Test
     public void shortenUrl() throws IOException {
-        final String url = "http://bit.ly/CdShort";
-        final Doc doc = new CdShortUrl(
-            // @checkstyle AnonInnerLengthCheck (1 lines)
-            new Doc() {
-                @Override
-                public boolean exists() throws IOException {
-                    return false;
-                }
-                @Override
-                public void delete() throws IOException {
-                    assert 1 != 0;
-                }
-                @Override
-                public Friends friends() throws IOException {
-                    return null;
-                }
-                @Override
-                public void read(final OutputStream output) throws IOException {
-                    output.close();
-                }
-                @Override
-                public void write(final InputStream input, final long size)
-                    throws IOException {
-                    input.close();
-                }
-                @Override
-                public String shortUrl() {
-                    return url;
-                }
-                @Override
-                public Attributes attributes() throws IOException {
-                    return null;
-                }
-            }
+        final Doc doc = Mockito.mock(Doc.class);
+        final String first = "http://bit.ly/1";
+        Mockito.when(doc.shortUrl()).thenReturn(first)
+            .thenReturn("http://bit.ly/2");
+        final Doc cdd = new CdShortUrl(doc);
+        MatcherAssert.assertThat(
+            cdd.shortUrl(),
+            Matchers.equalTo(first)
         );
         MatcherAssert.assertThat(
-            doc.shortUrl(),
-            Matchers.equalTo(url)
-        );
-        MatcherAssert.assertThat(
-            doc.shortUrl(),
-            Matchers.equalTo(url)
+            cdd.shortUrl(),
+            Matchers.equalTo(first)
         );
     }
 }


### PR DESCRIPTION
For #280 
- created `CdShortUrl` - `Doc` decorator which cache shortUrl() responses
- created the unit test
- `AwsDoc` instances cached with the decorator
