### PR TITLE
#221 Initial design for directory functionality

### DIFF
--- a/src/main/java/com/nerodesk/om/Dir.java
+++ b/src/main/java/com/nerodesk/om/Dir.java
@@ -27,45 +27,30 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.nerodesk.takes.doc;
+package com.nerodesk.om;
 
-import com.nerodesk.om.Base;
-import java.io.IOException;
-import org.takes.Request;
-import org.takes.Response;
-import org.takes.Take;
-import org.takes.facets.fork.FkRegex;
-import org.takes.facets.fork.TkFork;
+import com.jcabi.aspects.Immutable;
 
 /**
- * Takes for a directory.
+ * Directory.
  *
- * @author Grzegorz Gajos (grzegorz.gajos@opentangerine.com)
+ * @author Felipe Pina (felipe.pina@protonmail.com)
  * @version $Id$
  * @since 0.4
  */
-public final class TkDir implements Take {
+@Immutable
+public interface Dir {
 
     /**
-     * Base.
+     * Adds Docs to this Dir.
+     * @param docs Docs to add.
      */
-    private final transient Base base;
+    void add(Doc... docs);
 
     /**
-     * Ctor.
-     * @param bse Base.
+     * Removes Docs from this Dir.
+     * @param docs Docs to remove.
      */
-    public TkDir(final Base bse) {
-        this.base = bse;
-    }
+    void remove(Doc... docs);
 
-    // @todo #221:30min This class should have the ability to edit directories.
-    //  Specifically, implement the ability to remove and to attach existing
-    //  documents.
-    @Override
-    public Response act(final Request req) throws IOException {
-        return new TkFork(
-            new FkRegex("/dir/create", new TkDirCreate(this.base))
-        ).act(req);
-    }
 }

--- a/src/main/java/com/nerodesk/om/Dirs.java
+++ b/src/main/java/com/nerodesk/om/Dirs.java
@@ -27,45 +27,25 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.nerodesk.takes.doc;
+package com.nerodesk.om;
 
-import com.nerodesk.om.Base;
-import java.io.IOException;
-import org.takes.Request;
-import org.takes.Response;
-import org.takes.Take;
-import org.takes.facets.fork.FkRegex;
-import org.takes.facets.fork.TkFork;
+import com.jcabi.aspects.Immutable;
 
 /**
- * Takes for a directory.
+ * Directories.
  *
- * @author Grzegorz Gajos (grzegorz.gajos@opentangerine.com)
+ * @author Felipe Pina (felipe.pina@protonmail.com)
  * @version $Id$
  * @since 0.4
  */
-public final class TkDir implements Take {
+@Immutable
+public interface Dirs {
 
     /**
-     * Base.
+     * Creates a new directory at the root level.
+     * @param name Name of the new directory.
+     * @return Dir.
      */
-    private final transient Base base;
+    Dir create(String name);
 
-    /**
-     * Ctor.
-     * @param bse Base.
-     */
-    public TkDir(final Base bse) {
-        this.base = bse;
-    }
-
-    // @todo #221:30min This class should have the ability to edit directories.
-    //  Specifically, implement the ability to remove and to attach existing
-    //  documents.
-    @Override
-    public Response act(final Request req) throws IOException {
-        return new TkFork(
-            new FkRegex("/dir/create", new TkDirCreate(this.base))
-        ).act(req);
-    }
 }

--- a/src/main/java/com/nerodesk/takes/TkApp.java
+++ b/src/main/java/com/nerodesk/takes/TkApp.java
@@ -194,7 +194,7 @@ public final class TkApp extends TkWrap {
             ),
             new FkRegex(
                 "/dir/.*",
-                new TkSecure(new TkGreedy(new TkDir()))
+                new TkSecure(new TkGreedy(new TkDir(base)))
             )
         );
         return TkApp.fallback(

--- a/src/main/java/com/nerodesk/takes/doc/TkDirCreate.java
+++ b/src/main/java/com/nerodesk/takes/doc/TkDirCreate.java
@@ -33,6 +33,7 @@ import com.nerodesk.om.Base;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
+import org.takes.rs.RsEmpty;
 
 /**
  * Create directory.
@@ -60,7 +61,7 @@ public final class TkDirCreate implements Take {
     //  RqDir, analogous to RqDoc, to handle the actual directory creation.
     @Override
     public Response act(final Request request) {
-        throw new UnsupportedOperationException("#act()");
+        return new RsEmpty();
     }
 
 }

--- a/src/main/java/com/nerodesk/takes/doc/TkDirCreate.java
+++ b/src/main/java/com/nerodesk/takes/doc/TkDirCreate.java
@@ -30,21 +30,18 @@
 package com.nerodesk.takes.doc;
 
 import com.nerodesk.om.Base;
-import java.io.IOException;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
-import org.takes.facets.fork.FkRegex;
-import org.takes.facets.fork.TkFork;
 
 /**
- * Takes for a directory.
+ * Create directory.
  *
- * @author Grzegorz Gajos (grzegorz.gajos@opentangerine.com)
+ * @author Felipe Pina (felipe.pina@protonmail.com)
  * @version $Id$
  * @since 0.4
  */
-public final class TkDir implements Take {
+public final class TkDirCreate implements Take {
 
     /**
      * Base.
@@ -55,17 +52,15 @@ public final class TkDir implements Take {
      * Ctor.
      * @param bse Base.
      */
-    public TkDir(final Base bse) {
+    TkDirCreate(final Base bse) {
         this.base = bse;
     }
 
-    // @todo #221:30min This class should have the ability to edit directories.
-    //  Specifically, implement the ability to remove and to attach existing
-    //  documents.
+    // @todo #221:30min This is a stub implementation. We should create a class
+    //  RqDir, analogous to RqDoc, to handle the actual directory creation.
     @Override
-    public Response act(final Request req) throws IOException {
-        return new TkFork(
-            new FkRegex("/dir/create", new TkDirCreate(this.base))
-        ).act(req);
+    public Response act(final Request request) {
+        throw new UnsupportedOperationException("#act()");
     }
+
 }

--- a/src/main/java/com/nerodesk/takes/doc/TkDirCreate.java
+++ b/src/main/java/com/nerodesk/takes/doc/TkDirCreate.java
@@ -42,7 +42,7 @@ import org.takes.rs.RsEmpty;
  * @version $Id$
  * @since 0.4
  */
-@SuppressWarnings({"PMD.SingularField", "PMD.UnusedPrivateField"})
+@SuppressWarnings({ "PMD.SingularField", "PMD.UnusedPrivateField" })
 public final class TkDirCreate implements Take {
 
     /**

--- a/src/main/java/com/nerodesk/takes/doc/TkDirCreate.java
+++ b/src/main/java/com/nerodesk/takes/doc/TkDirCreate.java
@@ -58,7 +58,8 @@ public final class TkDirCreate implements Take {
     }
 
     // @todo #221:30min This is a stub implementation. We should create a class
-    //  RqDir, analogous to RqDoc, to handle the actual directory creation.
+    //  RqDir, analogous to RqDoc, to handle the actual directory creation. Make
+    //  sure to use the existing Dir and Dirs interfaces.
     @Override
     public Response act(final Request request) {
         return new RsEmpty();

--- a/src/main/java/com/nerodesk/takes/doc/TkDirCreate.java
+++ b/src/main/java/com/nerodesk/takes/doc/TkDirCreate.java
@@ -42,6 +42,7 @@ import org.takes.rs.RsEmpty;
  * @version $Id$
  * @since 0.4
  */
+@SuppressWarnings({"PMD.SingularField", "PMD.UnusedPrivateField"})
 public final class TkDirCreate implements Take {
 
     /**
@@ -59,7 +60,8 @@ public final class TkDirCreate implements Take {
 
     // @todo #221:30min This is a stub implementation. We should create a class
     //  RqDir, analogous to RqDoc, to handle the actual directory creation. Make
-    //  sure to use the existing Dir and Dirs interfaces.
+    //  sure to use the existing Dir and Dirs interfaces. Also remove the PMD
+    //  suppressions above.
     @Override
     public Response act(final Request request) {
         return new RsEmpty();

--- a/src/test/java/com/nerodesk/takes/doc/TkDirCreateTest.java
+++ b/src/test/java/com/nerodesk/takes/doc/TkDirCreateTest.java
@@ -30,6 +30,8 @@
 package com.nerodesk.takes.doc;
 
 import com.nerodesk.om.mock.MkBase;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.takes.rq.RqFake;
 
@@ -46,9 +48,12 @@ public final class TkDirCreateTest {
      * TkDirCreate can act.
      * @throws Exception If fails.
      */
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void acts() throws Exception {
-        new TkDirCreate(new MkBase()).act(new RqFake());
+        MatcherAssert.assertThat(
+            new TkDirCreate(new MkBase()).act(new RqFake()),
+            Matchers.notNullValue()
+        );
     }
 
 }

--- a/src/test/java/com/nerodesk/takes/doc/TkDirCreateTest.java
+++ b/src/test/java/com/nerodesk/takes/doc/TkDirCreateTest.java
@@ -29,43 +29,26 @@
  */
 package com.nerodesk.takes.doc;
 
-import com.nerodesk.om.Base;
-import java.io.IOException;
-import org.takes.Request;
-import org.takes.Response;
-import org.takes.Take;
-import org.takes.facets.fork.FkRegex;
-import org.takes.facets.fork.TkFork;
+import com.nerodesk.om.mock.MkBase;
+import org.junit.Test;
+import org.takes.rq.RqFake;
 
 /**
- * Takes for a directory.
+ * Tests for {@link TkDirCreate}.
  *
- * @author Grzegorz Gajos (grzegorz.gajos@opentangerine.com)
+ * @author Felipe Pina (felipe.pina@protonmail.com)
  * @version $Id$
  * @since 0.4
  */
-public final class TkDir implements Take {
+public final class TkDirCreateTest {
 
     /**
-     * Base.
+     * TkDirCreate can act.
+     * @throws Exception If fails.
      */
-    private final transient Base base;
-
-    /**
-     * Ctor.
-     * @param bse Base.
-     */
-    public TkDir(final Base bse) {
-        this.base = bse;
+    @Test(expected = UnsupportedOperationException.class)
+    public void acts() throws Exception {
+        new TkDirCreate(new MkBase()).act(new RqFake());
     }
 
-    // @todo #221:30min This class should have the ability to edit directories.
-    //  Specifically, implement the ability to remove and to attach existing
-    //  documents.
-    @Override
-    public Response act(final Request req) throws IOException {
-        return new TkFork(
-            new FkRegex("/dir/create", new TkDirCreate(this.base))
-        ).act(req);
-    }
 }

--- a/src/test/java/com/nerodesk/takes/doc/TkDirTest.java
+++ b/src/test/java/com/nerodesk/takes/doc/TkDirTest.java
@@ -29,6 +29,7 @@
  */
 package com.nerodesk.takes.doc;
 
+import com.nerodesk.om.mock.MkBase;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -50,7 +51,7 @@ public final class TkDirTest {
     @Test
     public void returnsTake() throws Exception {
         MatcherAssert.assertThat(
-            new TkDir().act(new RqFake("POST", "/dir/create")),
+            new TkDir(new MkBase()).act(new RqFake("POST", "/dir/create")),
             Matchers.notNullValue()
         );
     }


### PR DESCRIPTION
For #221
- added  class `TkDirCreate` + unit test
- `TkDir` now takes instance of `Base` in constructor
- added interfaces `Dir` and `Dirs`
- added puzzle for other directory operations
- added puzzle for creation of a `RqDir` class for bridge between request and `Dir`
