### PR TITLE
#301 bit.ly links are broken

### DIFF
--- a/src/main/java/com/nerodesk/om/SafeDoc.java
+++ b/src/main/java/com/nerodesk/om/SafeDoc.java
@@ -44,7 +44,7 @@ import lombok.ToString;
  * @since 0.3.30
  */
 @ToString
-@EqualsAndHashCode
+@EqualsAndHashCode(of = "decorated")
 public final class SafeDoc implements Doc {
     /**
      * Decorated.

--- a/src/main/java/com/nerodesk/om/SmallDoc.java
+++ b/src/main/java/com/nerodesk/om/SmallDoc.java
@@ -44,7 +44,7 @@ import lombok.ToString;
  * @since 0.4
  */
 @ToString
-@EqualsAndHashCode
+@EqualsAndHashCode(of = "decorated")
 public final class SmallDoc implements Doc {
     /**
      * Decorated.

--- a/src/main/java/com/nerodesk/om/aws/CdShortUrl.java
+++ b/src/main/java/com/nerodesk/om/aws/CdShortUrl.java
@@ -29,9 +29,7 @@
  */
 package com.nerodesk.om.aws;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.jcabi.aspects.Cacheable;
 import com.jcabi.aspects.Tv;
 import com.nerodesk.om.Attributes;
 import com.nerodesk.om.Doc;
@@ -39,7 +37,7 @@ import com.nerodesk.om.Friends;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -49,12 +47,8 @@ import lombok.EqualsAndHashCode;
  * @version $Id$
  * @since 0.3.30
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(of = "decorated")
 public final class CdShortUrl implements Doc {
-    /**
-     * Urls cache.
-     */
-    private static final CdShortUrl.CdUrls URLS = new CdShortUrl.CdUrls();
     /**
      * Decorated.
      */
@@ -95,49 +89,13 @@ public final class CdShortUrl implements Doc {
     }
 
     @Override
+    @Cacheable(lifetime = Tv.TWENTY, unit = TimeUnit.HOURS)
     public String shortUrl() {
-        return CdShortUrl.URLS.get(this.decorated);
+        return this.decorated.shortUrl();
     }
 
     @Override
     public Attributes attributes() throws IOException {
         return this.decorated.attributes();
-    }
-
-    /**
-     * Urls cache.
-     */
-    private static final class CdUrls {
-        /**
-         * Urls cache.
-         */
-        private final transient LoadingCache<Doc, String> urls;
-        /**
-         * Ctor.
-         */
-        CdUrls() {
-            this.urls = CacheBuilder.newBuilder()
-                .maximumSize(Tv.TEN * Tv.THOUSAND)
-                .build(
-                    new CacheLoader<Doc, String>() {
-                        @Override
-                        public String load(final Doc doc) {
-                            return doc.shortUrl();
-                        }
-                    });
-        }
-
-        /**
-         * Get short url for the doc.
-         * @param doc Doc
-         * @return Url
-         */
-        public String get(final Doc doc) {
-            try {
-                return this.urls.get(doc);
-            } catch (final ExecutionException ex) {
-                throw new IllegalStateException(ex);
-            }
-        }
     }
 }

--- a/src/main/java/com/nerodesk/om/mock/MkDoc.java
+++ b/src/main/java/com/nerodesk/om/mock/MkDoc.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
@@ -49,6 +50,7 @@ import org.apache.commons.io.IOUtils;
  * @version $Id$
  * @since 0.2
  */
+@EqualsAndHashCode(of = { "dir", "user", "label" })
 public final class MkDoc implements Doc {
 
     /**

--- a/src/test/java/com/nerodesk/om/SafeDocTest.java
+++ b/src/test/java/com/nerodesk/om/SafeDocTest.java
@@ -35,6 +35,8 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
@@ -85,5 +87,15 @@ public final class SafeDocTest {
         new SafeDoc(new MkDoc(file, "", "")).write(
             new ByteArrayInputStream(bytes), bytes.length
         );
+    }
+
+    /**
+     * SafeDoc conforms to equals and hashCode contract.
+     */
+    @Test
+    public void conformsToEqualsHashCodeContract() {
+        EqualsVerifier.forClass(SafeDoc.class)
+            .suppress(Warning.TRANSIENT_FIELDS)
+            .verify();
     }
 }

--- a/src/test/java/com/nerodesk/om/SmallDocTest.java
+++ b/src/test/java/com/nerodesk/om/SmallDocTest.java
@@ -36,6 +36,8 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -116,5 +118,15 @@ public final class SmallDocTest {
             doc.shortUrl(),
             Matchers.equalTo(file.toURI().toURL().toString())
         );
+    }
+
+    /**
+     * SmallDoc conforms to equals and hashCode contract.
+     */
+    @Test
+    public void conformsToEqualsHashCodeContract() {
+        EqualsVerifier.forClass(SmallDoc.class)
+            .suppress(Warning.TRANSIENT_FIELDS)
+            .verify();
     }
 }

--- a/src/test/java/com/nerodesk/om/aws/CdShortUrlTest.java
+++ b/src/test/java/com/nerodesk/om/aws/CdShortUrlTest.java
@@ -31,6 +31,8 @@ package com.nerodesk.om.aws;
 
 import com.nerodesk.om.Doc;
 import java.io.IOException;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -70,6 +72,16 @@ public final class CdShortUrlTest {
             sdoc.shortUrl(),
             Matchers.equalTo(second)
         );
+    }
+
+    /**
+     * CdShortUrl conforms to equals and hashCode contract.
+     */
+    @Test
+    public void conformsToEqualsHashCodeContract() {
+        EqualsVerifier.forClass(CdShortUrl.class)
+            .suppress(Warning.TRANSIENT_FIELDS)
+            .verify();
     }
 
     /**

--- a/src/test/java/com/nerodesk/om/aws/CdShortUrlTest.java
+++ b/src/test/java/com/nerodesk/om/aws/CdShortUrlTest.java
@@ -50,18 +50,37 @@ public final class CdShortUrlTest {
      */
     @Test
     public void shortenUrl() throws IOException {
-        final Doc doc = Mockito.mock(Doc.class);
         final String first = "http://bit.ly/1";
-        Mockito.when(doc.shortUrl()).thenReturn(first)
-            .thenReturn("http://bit.ly/2");
-        final Doc cdd = new CdShortUrl(doc);
+        final String second = "http://bit.ly/2";
+        final Doc fdoc = new CdShortUrl(this.doc(first));
+        final Doc sdoc = new CdShortUrl(this.doc(second));
         MatcherAssert.assertThat(
-            cdd.shortUrl(),
+            fdoc.shortUrl(),
             Matchers.equalTo(first)
         );
         MatcherAssert.assertThat(
-            cdd.shortUrl(),
+            fdoc.shortUrl(),
             Matchers.equalTo(first)
         );
+        MatcherAssert.assertThat(
+            sdoc.shortUrl(),
+            Matchers.equalTo(second)
+        );
+        MatcherAssert.assertThat(
+            sdoc.shortUrl(),
+            Matchers.equalTo(second)
+        );
+    }
+
+    /**
+     * Creates mocked Doc.
+     * @param name Doc name
+     * @return Doc instance
+     */
+    private Doc doc(final String name) {
+        final Doc doc = Mockito.mock(Doc.class);
+        Mockito.when(doc.shortUrl()).thenReturn(name)
+            .thenReturn(String.format("%s/next", name));
+        return doc;
     }
 }

--- a/src/test/java/com/nerodesk/om/mock/MkDocTest.java
+++ b/src/test/java/com/nerodesk/om/mock/MkDocTest.java
@@ -36,6 +36,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
@@ -161,5 +163,15 @@ public final class MkDocTest {
             doc.shortUrl(),
             Matchers.equalTo(file.toURI().toURL().toString())
         );
+    }
+
+    /**
+     * SafeDoc conforms to equals and hashCode contract.
+     */
+    @Test
+    public void conformsToEqualsHashCodeContract() {
+        EqualsVerifier.forClass(MkDoc.class)
+            .suppress(Warning.TRANSIENT_FIELDS)
+            .verify();
     }
 }


### PR DESCRIPTION
For #301
- Current cache implementation works inside Doc instance, but we create docs on every page load. It makes cache useless. Implemented single static cache for short urls to avoid this.
- improved the unit test
