### PR TITLE
#310 upgraded to Takes 0.20.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <dependency>
             <groupId>org.takes</groupId>
             <artifactId>takes</artifactId>
-            <version>0.16.9</version>
+            <version>0.20.1</version>
         </dependency>
         <dependency>
             <groupId>com.restfb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <dependency>
             <groupId>org.takes</groupId>
             <artifactId>takes</artifactId>
-            <version>0.20.1</version>
+            <version>0.20.2</version>
         </dependency>
         <dependency>
             <groupId>com.restfb</groupId>

--- a/src/main/java/com/nerodesk/takes/FbError.java
+++ b/src/main/java/com/nerodesk/takes/FbError.java
@@ -29,13 +29,12 @@
  */
 package com.nerodesk.takes;
 
-import java.util.Collections;
-import java.util.Iterator;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.takes.Response;
 import org.takes.facets.fallback.Fallback;
 import org.takes.facets.fallback.FbWrap;
 import org.takes.facets.fallback.RqFallback;
+import org.takes.misc.Opt;
 import org.takes.rs.RsText;
 import org.takes.rs.RsWithStatus;
 
@@ -55,11 +54,11 @@ public final class FbError extends FbWrap {
         super(
             new Fallback() {
                 @Override
-                public Iterator<Response> route(final RqFallback req) {
+                public Opt<Response> route(final RqFallback req) {
                     final String exc = ExceptionUtils.getStackTrace(
                         req.throwable()
                     );
-                    return Collections.<Response>singleton(
+                    return new Opt.Single<Response>(
                         new RsWithStatus(
                             new RsText(
                                 String.format(
@@ -69,7 +68,7 @@ public final class FbError extends FbWrap {
                             ),
                             req.code()
                         )
-                    ).iterator();
+                    );
                 }
             }
         );

--- a/src/test/java/com/nerodesk/takes/FbErrorTest.java
+++ b/src/test/java/com/nerodesk/takes/FbErrorTest.java
@@ -30,13 +30,13 @@
 package com.nerodesk.takes;
 
 import java.io.IOException;
-import java.util.Iterator;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.takes.Response;
 import org.takes.facets.fallback.RqFallback;
+import org.takes.misc.Opt;
 
 /**
  * Tests for {@link FbError}.
@@ -54,12 +54,12 @@ public final class FbErrorTest {
     @Test
     public void displaysErrorMsg() throws IOException {
         final String msg = "errormsg";
-        final Iterator<Response> iterator = new FbError().route(
+        final Opt<Response> opt = new FbError().route(
             new RqFallback.Fake(500, new IOException(msg))
         );
-        MatcherAssert.assertThat(iterator.hasNext(), Matchers.equalTo(true));
+        MatcherAssert.assertThat(opt.has(), Matchers.equalTo(true));
         MatcherAssert.assertThat(
-            IOUtils.toString(iterator.next().body()),
+            IOUtils.toString(opt.get().body()),
             Matchers.allOf(
                 Matchers.containsString("oops, something "),
                 Matchers.containsString("IOException"),


### PR DESCRIPTION
For #310 

upgraded to Takes 0.20.2 
fixed the file corrupt issue, 
I did compare the file hash before the upload and after the  download
on windows 
`certutil -hashfile test_movie_before.mp4`
`certutil -hashfile test_movie_after.mp4`
